### PR TITLE
Adds Dockerfile and Github action to build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag imginfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:22.04
+
+ADD . /imginfo/
+
+WORKDIR "/imginfo" 
+
+RUN apt-get update && apt-get -y install hdf5-helpers wget unzip build-essential libhdf5-dev libhdf5-serial-dev libbz2-dev
+RUN wget -O bitshuffle-master.zip https://github.com/kiyo-masui/bitshuffle/archive/refs/heads/master.zip && unzip bitshuffle-master.zip
+RUN wget -O HDF5Plugin-master.zip https://github.com/dectris/HDF5Plugin/archive/refs/heads/master.zip && unzip HDF5Plugin-master.zip
+RUN wget -O HDF5-External-Filter-Plugins-master.zip https://github.com/nexusformat/HDF5-External-Filter-Plugins/archive/refs/heads/master.zip && unzip HDF5-External-Filter-Plugins-master.zip
+
+RUN make

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ HXXFLAGS += -DUSE_HDF5
 LDFLAGS  += -L$(HDF5_LIB) -lhdf5 -lz -lbz2
 
 COMPILE.hxx = $(HXX) $(HXXFLAGS) -c -o $(1) $(2)
-COMPILE.hcc = $(HCC) $(HCCFLAGS) -c -o $(1) $(2)
+COMPILE.hcc = $(HCC) $(HCCFLAGS) -c -o $(1) $(2) -I $(BITSHUFFLE_MASTER)/lz4
 LINK.hxx    = $(HXX) $(HXXFLAGS)    -o $(1) $(2) $(LDFLAGS)
 LINK.hcc    = $(HCC) $(HCCFLAGS)    -o $(1) $(2) $(LDFLAGS)
 

--- a/imginfo.c
+++ b/imginfo.c
@@ -2446,7 +2446,7 @@ char *hdf5_read_group_attribute(hid_t fid, const char* item, const char* attribu
       hid_t attribute_space = H5Aget_space(attribute_id);
       size_t attribute_n = H5Tget_size(attribute_type);
       r = (char *)malloc(sizeof(char)*(attribute_n+1));
-      status H5Aread(attribute_id, attribute_type, r);
+      status = H5Aread(attribute_id, attribute_type, r);
       // safety net (assume H5T_STR_NULLPAD)
       // see also: https://github.com/h5py/h5py/issues/727
       //           https://forum.hdfgroup.org/t/bug-writing-a-string-does-not-include-null-terminator/5281


### PR DESCRIPTION
As part of fixing the errors in writing NeXus files from i03 at DLS recently it will be useful to have a reproducible build in CI.

This PR:
* Adds a `Dockerfile` that builds `imginfo`
* Puts building the `Dockerfile` into CI on this repo so that it is built on every merge to main or every PR
* Fixes the build

To test:
* Run `docker build . --file Dockerfile --tag imginfo` and then `docker run -t imginfo:latest ./imginfo -h` and confirm that you get the help output from `imginfo`
* Confirm the action has passed on this PR (https://github.com/DominicOram/imginfo/actions/runs/8971509173/job/24637396237) and failed before the build was fixed (https://github.com/DominicOram/imginfo/actions/runs/8971425015/job/24637133439)